### PR TITLE
fix: Support for Non-json secret fetched from Delinea SecretServer

### DIFF
--- a/pkg/provider/secretserver/client.go
+++ b/pkg/provider/secretserver/client.go
@@ -62,36 +62,30 @@ func (c *client) GetSecret(ctx context.Context, ref esv1.ExternalSecretDataRemot
 		return jsonStr, nil
 	}
 
-	// Keep original behavior of decoding first Item into gjson
-	if len(secret.Fields) == 1 {
-		// extract first "field" i.e. Items.0.ItemValue, data from secret using gjson
-		val := gjson.Get(string(jsonStr), "Items.0.ItemValue")
-		if !val.Exists() {
-			return nil, esv1.NoSecretError{}
-		}
+	// extract first "field" i.e. Items.0.ItemValue, data from secret using gjson
+	val := gjson.Get(string(jsonStr), "Items.0.ItemValue")
+	if val.Exists() && gjson.Valid(val.String()) {
 		// extract specific value from data directly above using gjson
 		out := gjson.Get(val.String(), ref.Property)
-		if !out.Exists() {
-			return nil, esv1.NoSecretError{}
+		if out.Exists() {
+			return []byte(out.String()), nil
 		}
-		return []byte(out.String()), nil
-	} else {
-		// More general case Fields is an array in DelineaXPM/tss-sdk-go/v2/server
-		// https://github.com/DelineaXPM/tss-sdk-go/blob/571e5674a8103031ad6f873453db27959ec1ca67/server/secret.go#L23
-		secretMap := make(map[string]string)
-
-		for index := range secret.Fields {
-			secretMap[secret.Fields[index].FieldName] = secret.Fields[index].ItemValue
-			secretMap[secret.Fields[index].Slug] = secret.Fields[index].ItemValue
-		}
-
-		out, ok := secretMap[ref.Property]
-		if !ok {
-			return nil, esv1.NoSecretError{}
-		}
-
-		return []byte(out), nil
 	}
+
+	// More general case Fields is an array in DelineaXPM/tss-sdk-go/v2/server
+	// https://github.com/DelineaXPM/tss-sdk-go/blob/571e5674a8103031ad6f873453db27959ec1ca67/server/secret.go#L23
+	secretMap := make(map[string]string)
+	for index := range secret.Fields {
+		secretMap[secret.Fields[index].FieldName] = secret.Fields[index].ItemValue
+		secretMap[secret.Fields[index].Slug] = secret.Fields[index].ItemValue
+	}
+
+	out, ok := secretMap[ref.Property]
+	if !ok {
+		return nil, esv1.NoSecretError{}
+	}
+
+	return []byte(out), nil
 }
 
 // Not supported at this time.

--- a/pkg/provider/secretserver/client_test.go
+++ b/pkg/provider/secretserver/client_test.go
@@ -101,6 +101,8 @@ func newTestClient() esv1.SecretsClient {
 				createSecret(2000, "{ \"user\": \"helloWorld\", \"password\": \"badPassword\",\"server\":[ \"192.168.1.50\",\"192.168.1.51\"] }"),
 				createSecret(3000, "{ \"user\": \"chuckTesta\", \"password\": \"badPassword\",\"server\":\"192.168.1.50\"}"),
 				createTestSecretFromCode(4000),
+				createSecret(5000, "non-json-value"),
+				createSecret(6000, "{ malformed: true, "),
 			},
 		},
 	}
@@ -159,6 +161,12 @@ func TestGetSecretSecretServer(t *testing.T) {
 			},
 			want: jsonStr,
 		},
+		"Secret with non-JSON value, no property requested, returns raw string": {
+			ref: esv1.ExternalSecretDataRemoteRef{
+				Key: "5000",
+			},
+			want: []byte(`non-json-value`),
+		},
 		"Secret from code: existent key with no property": {
 			ref: esv1.ExternalSecretDataRemoteRef{
 				Key: "4000",
@@ -193,6 +201,14 @@ func TestGetSecretSecretServer(t *testing.T) {
 				Property: "passwordkey",
 			},
 			want: []byte(nil),
+			err:  esv1.NoSecretError{},
+		},
+		"Secret with malformed JSON: property access fails with NoSecretError": {
+			ref: esv1.ExternalSecretDataRemoteRef{
+				Key:      "6000",
+				Property: "foo",
+			},
+			want: nil,
 			err:  esv1.NoSecretError{},
 		},
 	}


### PR DESCRIPTION
## Problem Statement
Custom secret templates in Delinea Secret Server that use a single field with a plain text (non-JSON) value currently fail when a specific property is defined in an ExternalSecret. The existing logic assumes Items[0].ItemValue contains a JSON blob, which breaks compatibility with simple or flat template formats.

What is the problem you're trying to solve?

## Related Issue
No issue yet. See the linked discussion above. Please let be know if you absolutely need an issue for tracking this PR.

## Proposed Changes
Adds hybrid logic in the GetSecret method:
First attempts to extract the field using GJSON if Items[0].ItemValue is valid JSON.
Falls back to a flat map lookup using both fieldName and slug from the Fields array if JSON extraction fails.
This improves compatibility with single-field templates where ItemValue is a plain string and not JSON.
Ensures legacy behavior for structured JSON values remains intact.



